### PR TITLE
[Issue-1495] Fixed postinstall script generating invalid "cdn.conf" file

### DIFF
--- a/traffic_ops/install/lib/GenerateCert.pm
+++ b/traffic_ops/install/lib/GenerateCert.pm
@@ -70,13 +70,9 @@ sub writeCdn_conf {
         };
     }
 
-    # dump conf data in compact but readable form
-    my $dumper = Data::Dumper->new( [$cdnh] );
-    $dumper->Indent(1)->Terse(1)->Quotekeys(0);
-
     # write whole config to temp file in pwd (keeps in same filesystem)
     my $tmpfile = File::Temp->new( DIR => '.' );
-    print $tmpfile $dumper->Dump();
+    writeJson("$tmpfile", $cdnh);
     close $tmpfile;
 
     # make backup of current file


### PR DESCRIPTION
Instead of GenerateCert.pm creating configuration files using Data::Dumper, it uses the InstallUtils::writeJson method. Now, when later parts of the postinstall script try to load cdn.conf as json, it does not fail because the file format is wrong.